### PR TITLE
Remove 'dir' parameter to mkstemp

### DIFF
--- a/wget.py
+++ b/wget.py
@@ -300,7 +300,7 @@ def download(url, out=None, bar=bar_adaptive):
     names["url"] = filename_from_url(url)
     # get filename for temp file in current directory
     prefix = (names["url"] or names["out"] or ".") + "."
-    (fd, tmpfile) = tempfile.mkstemp(".tmp", prefix=prefix, dir=".")
+    (fd, tmpfile) = tempfile.mkstemp(".tmp", prefix=prefix)
     os.close(fd)
     os.unlink(tmpfile)
 


### PR DESCRIPTION
Specifying '.' as the directory to make the tmpfile in, can cause an exception if the program is run from a directory in which the user does not have write permissions.  For example, if the user does "cd /" and then runs a program which uses this library, wget.download will die with an exception.  I removed the 'dir' parameter which allows mkstemp to choose an appropriate tmp directory for the file.