### PR TITLE
Fix issue return of download() with parameter out ending with a slash

### DIFF
--- a/wget.py
+++ b/wget.py
@@ -317,7 +317,7 @@ def download(url, out=None, bar=bar_adaptive):
     names["header"] = filename_from_headers(headers)
     if os.path.isdir(names["out"]):
         filename = names["header"] or names["url"]
-        filename = names["out"] + "/" + filename
+        filename = os.path.join(names["out"], filename)
     else:
         filename = names["out"] or names["header"] or names["url"]
     # add numeric ' (x)' suffix if filename already exists


### PR DESCRIPTION
```python3
import os
import wget

test_path_ending_with_slash = 'test/'
os.mkdir(test_path_ending_with_slash)
f = wget.download('https://example.org/file.txt', out=test_path_ending_with_slash)

print(f)

```

Output:
- Previously: `test//file.txt`
- Now: `test/file.txt`